### PR TITLE
Fixed config file name could not be customized.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "title": "woocommerce-local-store",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Manages product stocks in multiple local stores.",
   "author": {
     "name": "netzstrategen",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 // phpcs:disable
 /*
   Plugin Name: WooCommerce Local Store
-  Version: 1.0.0
+  Version: 1.0.1
   Text Domain: woocommerce-local-store
   Description: Manages product stocks in multiple local stores.
   Author: netzstrategen

--- a/src/Config.php
+++ b/src/Config.php
@@ -93,7 +93,7 @@ class Config {
    * @return string
    *   The config file name.
    */
-  public static function getConfigFileName() {
+  public static function getConfigFileName(): string {
     return defined('WOOCOMMERCE_LOCAL_STORE_CONFIG_FILE') ?
       WOOCOMMERCE_LOCAL_STORE_CONFIG_FILE :
       static::CONFIG_FILE;

--- a/src/Config.php
+++ b/src/Config.php
@@ -34,7 +34,7 @@ class Config {
   public static function get(?string $store_id = NULL): array {
     if (!isset(static::$cache)) {
       try {
-        $data = static::readDataFile(self::CONFIG_FILE);
+        $data = static::readDataFile(self::getConfigFileName());
         if (!static::$cache = json_decode($data, TRUE)) {
           throw new \Exception('Unable to decode the configuration.');
         }
@@ -85,6 +85,18 @@ class Config {
       throw new \Exception("Unable to read file '$path'.");
     }
     return $str;
+  }
+
+  /**
+   * Retrieves the plugin config file name.
+   *
+   * @return string
+   *   The config file name.
+   */
+  public static function getConfigFileName() {
+    return defined('WOOCOMMERCE_LOCAL_STORE_CONFIG_FILE') ?
+      WOOCOMMERCE_LOCAL_STORE_CONFIG_FILE :
+      static::CONFIG_FILE;
   }
 
 }


### PR DESCRIPTION
Related to task [Adjust plugin woocommerce-local-store to work in shared code base cases](https://app.asana.com/0/1199938965307042/1202011468389848/f)