### PR TITLE
Added WPGraphQL support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "title": "woocommerce-local-store",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Manages product stocks in multiple local stores.",
   "author": {
     "name": "netzstrategen",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 // phpcs:disable
 /*
   Plugin Name: WooCommerce Local Store
-  Version: 1.0.3
+  Version: 1.1.0
   Text Domain: woocommerce-local-store
   Description: Manages product stocks in multiple local stores.
   Author: netzstrategen

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Netzstrategen\WooCommerceLocalStore;
+
+/**
+ * GraphQL related functionalities.
+ */
+class GraphQL {
+
+  /**
+   * @implements graphql_register_types
+   */
+  public static function graphql_register_types() {
+    self::registerLocalStockObjectType();
+    self::registerLocalStockField('product');
+    self::registerLocalStockField('ProductVariation');
+  }
+
+  /**
+   * Registers localStock object type.
+   */
+  public static function registerLocalStockObjectType():void {
+
+    register_graphql_object_type(
+      'localStock',
+      [
+        'description' => __('Local stock', Plugin::L10N),
+        'fields'      => [
+          'storeName' => [
+            'type'        => 'String',
+            'description' => __('Store name', Plugin::L10N),
+          ],
+          'showroom'  => [
+            'type'        => 'String',
+            'description' => __('Showroom', Plugin::L10N),
+          ],
+          'warehouse'       => [
+            'type'        => 'String',
+            'description' => __('Warehouse', Plugin::L10N),
+          ],
+          'online'       => [
+            'type'        => 'String',
+            'description' => __('Online', Plugin::L10N),
+          ],
+        ],
+      ]
+    );
+  }
+
+  /**
+   * Registers localStock field.
+   */
+  public static function registerLocalStockField($type_name):void {
+    register_graphql_field(
+      $type_name,
+      'localStock',
+      [
+        'description' => __('Local stocks availability', Plugin::L10N),
+        'type'        => ['list_of' => 'localStock'],
+        'resolve'     => function($source) {
+          $product = $source->as_WC_Data();
+          $localStock = [];
+
+          if (Product::is_category_excluded()) {
+            return $localStock;
+          }
+
+          if ($local_stock_raw_data = Product::getStockByStore($product)) {
+            foreach($local_stock_raw_data as $key => $value) {
+              $localStock[] = [
+                'storeName' => $key ?? '',
+                'showroom' => $value['showroom'] ?? '',
+                'warehouse' => $value['warehouse'] ?? '',
+                'online' => $value['online'] ?? '',
+              ];
+            }
+          }
+
+          return $localStock;
+        }
+      ]
+    );
+  }
+
+}

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -13,7 +13,7 @@ class GraphQL {
   public static function graphql_register_types() {
     self::registerLocalStoreStockStatusEnum();
     self::registerLocalStockObjectType();
-    self::registerLocalStockField('product');
+    self::registerLocalStockField('Product');
     self::registerLocalStockField('ProductVariation');
   }
 
@@ -44,7 +44,7 @@ class GraphQL {
       [
         'description' => __('Local stock', Plugin::L10N),
         'fields' => [
-          'storeName' => [
+          'label' => [
             'type' => 'String',
             'description' => __('Store name', Plugin::L10N),
           ],
@@ -86,7 +86,7 @@ class GraphQL {
         if ($local_stock_raw_data = Product::getStockByStore($product)) {
           foreach ($local_stock_raw_data as $key => $value) {
             $local_stock[] = [
-              'storeName' => $key ?? '',
+              'label' => $key ?? '',
               'showroom' => $value['showroom'] ?? '',
               'warehouse' => $value['warehouse'] ?? '',
               'online' => $value['online'] ?? '',

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -11,7 +11,7 @@ class GraphQL {
    * @implements graphql_register_types
    */
   public static function graphql_register_types() {
-    self::registerLocalStockStatusEnum();
+    self::registerLocalStoreStockStatusEnum();
     self::registerLocalStockObjectType();
     self::registerLocalStockField('product');
     self::registerLocalStockField('ProductVariation');
@@ -20,18 +20,17 @@ class GraphQL {
   /**
    * Registers local stock status enum.
    */
-  public static function registerLocalStockStatusEnum() {
-    $values = [
-      'HIGH' => ['value' => 'high'],
-      'LOW' => ['value' => 'low'],
-      'NONE' => ['value' => 'none'],
-    ];
+  public static function registerLocalStoreStockStatusEnum() {
 
     register_graphql_enum_type(
-    'LocalStockStatus',
+    'LocalStoreStockStatus',
     [
       'description' => __('Local stock status enumeration', Plugin::L10N),
-      'values' => $values,
+      'values' => [
+        'high' => ['value' => 'high'],
+        'low' => ['value' => 'low'],
+        'none' => ['value' => 'none'],
+      ],
     ]
     );
   }
@@ -50,15 +49,15 @@ class GraphQL {
             'description' => __('Store name', Plugin::L10N),
           ],
           'showroom' => [
-            'type' => 'LocalStockStatus',
+            'type' => 'LocalStoreStockStatus',
             'description' => __('Showroom', Plugin::L10N),
           ],
           'warehouse' => [
-            'type' => 'LocalStockStatus',
+            'type' => 'LocalStoreStockStatus',
             'description' => __('Warehouse', Plugin::L10N),
           ],
           'online' => [
-            'type' => 'LocalStockStatus',
+            'type' => 'LocalStoreStockStatus',
             'description' => __('Online', Plugin::L10N),
           ],
         ],
@@ -73,35 +72,31 @@ class GraphQL {
    *   The type name where to register the field.
    */
   public static function registerLocalStockField(string $type_name) {
-    register_graphql_field(
-      $type_name,
-      'localStock',
-      [
-        'description' => __('Local stocks availability', Plugin::L10N),
-        'type' => ['list_of' => 'localStock'],
-        'resolve' => function ($source) {
-          $product = $source->as_WC_Data();
-          $localStock = [];
+    register_graphql_field($type_name, 'localStock', [
+      'description' => __('Local stocks availability', Plugin::L10N),
+      'type' => ['list_of' => 'localStock'],
+      'resolve' => function ($source) {
+        $product = $source->as_WC_Data();
+        $local_stock = [];
 
-          if (Product::isCategoryExcluded()) {
-            return $localStock;
-          }
-
-          if ($local_stock_raw_data = Product::getStockByStore($product)) {
-            foreach ($local_stock_raw_data as $key => $value) {
-              $localStock[] = [
-                'storeName' => $key ?? '',
-                'showroom' => $value['showroom'] ?? '',
-                'warehouse' => $value['warehouse'] ?? '',
-                'online' => $value['online'] ?? '',
-              ];
-            }
-          }
-
-          return $localStock;
+        if (Product::isCategoryExcluded()) {
+          return $local_stock;
         }
-      ]
-    );
+
+        if ($local_stock_raw_data = Product::getStockByStore($product)) {
+          foreach ($local_stock_raw_data as $key => $value) {
+            $local_stock[] = [
+              'storeName' => $key ?? '',
+              'showroom' => $value['showroom'] ?? '',
+              'warehouse' => $value['warehouse'] ?? '',
+              'online' => $value['online'] ?? '',
+            ];
+          }
+        }
+
+        return $local_stock;
+      }
+    ]);
   }
 
 }

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -11,35 +11,54 @@ class GraphQL {
    * @implements graphql_register_types
    */
   public static function graphql_register_types() {
+    self::registerLocalStockStatusEnum();
     self::registerLocalStockObjectType();
     self::registerLocalStockField('product');
     self::registerLocalStockField('ProductVariation');
   }
 
   /**
+   * Registers local stock status enum.
+   */
+  public static function registerLocalStockStatusEnum() {
+    $values = [
+      'HIGH' => ['value' => 'high'],
+      'LOW' => ['value' => 'low'],
+      'NONE' => ['value' => 'none'],
+    ];
+
+    register_graphql_enum_type(
+    'LocalStockStatus',
+    [
+      'description' => __('Local stock status enumeration', Plugin::L10N),
+      'values' => $values,
+    ]
+    );
+  }
+
+  /**
    * Registers localStock object type.
    */
-  public static function registerLocalStockObjectType():void {
-
+  public static function registerLocalStockObjectType() {
     register_graphql_object_type(
       'localStock',
       [
         'description' => __('Local stock', Plugin::L10N),
-        'fields'      => [
+        'fields' => [
           'storeName' => [
-            'type'        => 'String',
+            'type' => 'String',
             'description' => __('Store name', Plugin::L10N),
           ],
-          'showroom'  => [
-            'type'        => 'String',
+          'showroom' => [
+            'type' => 'LocalStockStatus',
             'description' => __('Showroom', Plugin::L10N),
           ],
-          'warehouse'       => [
-            'type'        => 'String',
+          'warehouse' => [
+            'type' => 'LocalStockStatus',
             'description' => __('Warehouse', Plugin::L10N),
           ],
-          'online'       => [
-            'type'        => 'String',
+          'online' => [
+            'type' => 'LocalStockStatus',
             'description' => __('Online', Plugin::L10N),
           ],
         ],
@@ -49,24 +68,27 @@ class GraphQL {
 
   /**
    * Registers localStock field.
+   *
+   * @param string $type_name
+   *   The type name where to register the field.
    */
-  public static function registerLocalStockField($type_name):void {
+  public static function registerLocalStockField(string $type_name) {
     register_graphql_field(
       $type_name,
       'localStock',
       [
         'description' => __('Local stocks availability', Plugin::L10N),
-        'type'        => ['list_of' => 'localStock'],
-        'resolve'     => function($source) {
+        'type' => ['list_of' => 'localStock'],
+        'resolve' => function ($source) {
           $product = $source->as_WC_Data();
           $localStock = [];
 
-          if (Product::is_category_excluded()) {
+          if (Product::isCategoryExcluded()) {
             return $localStock;
           }
 
           if ($local_stock_raw_data = Product::getStockByStore($product)) {
-            foreach($local_stock_raw_data as $key => $value) {
+            foreach ($local_stock_raw_data as $key => $value) {
               $localStock[] = [
                 'storeName' => $key ?? '',
                 'showroom' => $value['showroom'] ?? '',

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -36,6 +36,9 @@ class Plugin {
     add_action('woocommerce_process_product_meta', __NAMESPACE__ . '\Product::woocommerce_process_product_meta');
     add_action('woocommerce_save_product_variation', __NAMESPACE__ . '\Product::woocommerce_save_product_variation', 10, 2);
 
+    // GraphQL support.
+    add_action('graphql_register_types', __NAMESPACE__ . '\GraphQL::graphql_register_types');
+
     if (is_admin()) {
       return;
     }

--- a/src/Product.php
+++ b/src/Product.php
@@ -209,7 +209,7 @@ class Product {
    * Displays the shop stock-status component on the front-end.
    */
   public static function display_store_stock_status_block() {
-    if (self::is_category_excluded()) {
+    if (self::isCategoryExcluded()) {
       return;
     }
 
@@ -234,7 +234,7 @@ class Product {
    * @return bool
    *   True if the product is within a excluded category, otherwise false.
    */
-  public static function is_category_excluded():bool {
+  public static function isCategoryExcluded():bool {
     return has_term(Product::CATEGORY_EXCLUDED, 'product_cat');
   }
 

--- a/src/Product.php
+++ b/src/Product.php
@@ -229,12 +229,12 @@ class Product {
   }
 
   /**
-   * Checks whether a product in a given category shall show its stock status.
+   * Returns whether the stock status should be shown for a product based on its category.
    *
    * @return bool
    *   True if the product is within a excluded category, otherwise false.
    */
-  public static function isCategoryExcluded():bool {
+  public static function isCategoryExcluded(): bool {
     return has_term(Product::CATEGORY_EXCLUDED, 'product_cat');
   }
 

--- a/src/Product.php
+++ b/src/Product.php
@@ -209,7 +209,7 @@ class Product {
    * Displays the shop stock-status component on the front-end.
    */
   public static function display_store_stock_status_block() {
-    if (has_term(Product::CATEGORY_EXCLUDED, 'product_cat')) {
+    if (self::is_category_excluded()) {
       return;
     }
 
@@ -226,6 +226,16 @@ class Product {
       'raw' => $raw,
       'stocks' => $stocks,
     ]);
+  }
+
+  /**
+   * Checks whether a product in a given category shall show its stock status.
+   *
+   * @return bool
+   *   True if the product is within a excluded category, otherwise false.
+   */
+  public static function is_category_excluded():bool {
+    return has_term(Product::CATEGORY_EXCLUDED, 'product_cat');
   }
 
 }


### PR DESCRIPTION
Ticket:
https://app.asana.com/0/1201154968324561/1202659778651600

This PR adds support for WPGraphQL by adding a new field to both the `product` and `ProductVariation` object types.

If a product is within an excluded category an empty array will be provided. (E.g `Abverkauf` is one of the excluded ones)
![image](https://user-images.githubusercontent.com/18492002/191743261-8ed90b57-26e2-465e-900f-19da2d3df0d4.png)

The possible values are high, low, or none.

and should be mapped to different colors:

<img width="591" alt="image" src="https://user-images.githubusercontent.com/18492002/189887491-1c8b51ea-5974-4e0e-a50c-926c453a54aa.png">

```graphql
{
  products(first: 100) {
    nodes {
      ... on VariableProduct {
        name
        databaseId
        localStock {
          label
          online
          showroom
          warehouse
        }
        variations {
          nodes {
            databaseId
            localStock {
              label
              online
              showroom
              warehouse
            }
          }
        }
      }
    }
  }
}
```
